### PR TITLE
Fixes from forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ TODO RUNS false
 # you can mark known test cases as SKIP when then
 # are known not to run under some condition
 SKIP test $(uname -s) == Darwin # Tests dont run under Darwin
+```
 
 #### Running Skip Tests
 

--- a/osht.sh
+++ b/osht.sh
@@ -103,7 +103,7 @@ function _osht_cleanup {
 trap _osht_cleanup INT TERM EXIT
 
 function _osht_xmlencode {
-    sed -e 's/\&/\&amp;/g' -e 's/\"/\&quot;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' 
+    sed -e 's/\&/\&amp;/g' -e 's/\"/\&quot;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/\'/\&apos;/g'
 }
 
 function _osht_strip_terminal_escape {

--- a/osht.sh
+++ b/osht.sh
@@ -103,7 +103,7 @@ function _osht_cleanup {
 trap _osht_cleanup INT TERM EXIT
 
 function _osht_xmlencode {
-    sed -e 's/\&/\&amp;/g' -e 's/\"/\&quot;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/\'/\&apos;/g'
+    sed -e 's/\&/\&amp;/g' -e 's/\"/\&quot;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e "s/'/\&apos;/g"
 }
 
 function _osht_strip_terminal_escape {

--- a/osht.sh
+++ b/osht.sh
@@ -23,6 +23,7 @@
 : ${OSHT_STDIO=$($OSHT_MKTEMP)}
 : ${OSHT_VERBOSE=}
 : ${OSHT_WATCH=}
+: ${OSHT_OVERRIDE_TRAP=}
 
 : ${_OSHT_CURRENT_TEST_FILE=$($OSHT_MKTEMP)}
 : ${_OSHT_CURRENT_TEST=0}
@@ -100,7 +101,19 @@ function _osht_cleanup {
     exit $rv
 }
 
-trap _osht_cleanup INT TERM EXIT
+appendTrap() {
+    HANDLER=$1
+    shift
+    SIGNALS="$*"
+    eval "set -- $(trap -p ${SIGNALS})"
+    trap -- "${3}${3:+;}${HANDLER}" ${SIGNALS}
+}
+
+if [ -n "$OSHT_OVERRIDE_TRAP" ]; then
+	trap _osht_cleanup INT TERM EXIT
+else
+	appendTrap _osht_cleanup INT TERM EXIT
+fi
 
 function _osht_xmlencode {
     sed -e 's/\&/\&amp;/g' -e 's/\"/\&quot;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' 

--- a/osht.sh
+++ b/osht.sh
@@ -103,7 +103,7 @@ function _osht_cleanup {
 trap _osht_cleanup INT TERM EXIT
 
 function _osht_xmlencode {
-    sed -e 's/\&/\&amp;/g' -e 's/\"/\&quot;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' 
+    sed -e 's/\&/\&amp;/g' -e 's/\"/\&quot;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e "s/'/\&apos;/g"
 }
 
 function _osht_strip_terminal_escape {

--- a/osht.sh
+++ b/osht.sh
@@ -121,7 +121,8 @@ function _osht_timestamp {
 function _osht_init_junit {
     cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites failures="$(_osht_failed)" name="$0" tests="$_OSHT_PLANNED_TESTS" time="$SECONDS" timestamp="$(_osht_timestamp)" >
+<testsuites>
+<testsuite failures="$(_osht_failed)" name="$0" tests="$_OSHT_PLANNED_TESTS" time="$SECONDS" timestamp="$(_osht_timestamp)" >
 EOF
 }
 
@@ -147,6 +148,7 @@ EOF
 
 function _osht_end_junit {
     cat <<EOF
+</testsuite>
 </testsuites>
 EOF
 }

--- a/osht.sh
+++ b/osht.sh
@@ -103,7 +103,7 @@ function _osht_cleanup {
 trap _osht_cleanup INT TERM EXIT
 
 function _osht_xmlencode {
-    sed -e 's/\&/\&amp;/g' -e 's/\"/\&quot;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e "s/'/\&apos;/g"
+    sed -e 's/\&/\&amp;/g' -e 's/\"/\&quot;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e "s/'//g" # -e "s/'/\&apos;/g"
 }
 
 function _osht_strip_terminal_escape {


### PR DESCRIPTION
Integrated changes from https://github.com/w8jcik/osht.git
- 3515539 - Remove single quotes from names entirely (fix escaping of &apos in xml)

https://github.com/dcsobral/osht.git
- ae66fc0 - Fix JUnit XML output (fixes Emit <testsuite> tag(s) #5)
- c00778d - Append instead of overriding trap handler (fixes OSHT overrides trap handlers #6)
